### PR TITLE
Fix build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "scripts": {
     "build": "npm run webui-build && npm run lambda-build && npm run cfn-build",
     "cfn-build": "npm run cfn-package && npm run lambda-inline",
-    "cfn-ensure-dist": "if [ ! -d './dist' ]; then mkdir dist; fi",
-    "cfn-package": "npm run cfn-ensure-dist && cfn-flip -c -n -l src/cfn/template.yaml dist/template.yaml",
     "cfn-deploy": "npm run cfn-deploy-template && npm run cfn-deploy-stack",
     "cfn-deploy-stack": "aws cloudformation deploy --template-file ./dist/template.yaml --region eu-west-1 --capabilities CAPABILITY_IAM --parameter-overrides CollectionId=RekoDemo --stack-name rekodemo",
     "cfn-deploy-template": "aws s3 cp ./dist/template.yaml s3://rekognition-engagement-meter/ --acl public-read",
+    "cfn-ensure-dist": "if [ ! -d './dist' ]; then mkdir dist; fi",
+    "cfn-package": "npm run cfn-ensure-dist && cfn-flip -c -n -l src/cfn/template.yaml dist/template.yaml",
     "deploy": "npm run webui-deploy && npm run cfn-deploy",
     "lambda-build": "cd src/functions/setup && npm run build",
     "lambda-inline": "cd src/functions/setup && npm run inline",


### PR DESCRIPTION
*Description of changes:*
During #18 we made the dist folder gitignored. Unfortunately when the folder is not there the build fails. 

In this PR I included 2 things:
1) Create the folder if it doesn't exist during build
2) Avoid running cloudformation package, as we don't need to upload anything to s3, rather just use flip in order to standardize the YAML file and inline the lambda without depending on s3 during build.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
