### PR TITLE
Fix build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ before_script:
 
 after_success:
   - if [ $TRAVIS_PULL_REQUEST == false ] && [ $TRAVIS_BRANCH == "master" ]; then
-      npm run taskcat
-    fi
+        npm run taskcat;
+      fi
 
 notifications:
   email: false


### PR DESCRIPTION
Travis issue happening only after master merge:

```
$ if [ $TRAVIS_PULL_REQUEST == false ] && [ $TRAVIS_BRANCH == "master" ]; then npm run taskcat fi
/home/travis/.travis/job_stages: eval: line 105: syntax error: unexpected end of file
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
