### PR TITLE
Improve Developer Experience

### DIFF
--- a/src/web-ui/src/App.js
+++ b/src/web-ui/src/App.js
@@ -8,6 +8,7 @@ import CameraHelp from "./components/CameraHelp";
 import EngagementSummary from "./components/EngagementsSummary";
 import Header from "./components/Header";
 import PolarChart from "./components/PolarChart";
+import SettingsHelp from "./components/SettingsHelp";
 
 import faceDetailsMapper from "./utils/faceDetailsMapper";
 import getChartData from "./utils/getChartData";
@@ -114,6 +115,7 @@ export default () => {
         readyToStream={readyToStream}
       />
       <Grid>
+        <SettingsHelp show={!window.rekognitionSettings} />
         <CameraHelp show={!readyToStream} />
         <Row>
           <Col md={12} sm={6}>

--- a/src/web-ui/src/components/SettingsHelp.js
+++ b/src/web-ui/src/components/SettingsHelp.js
@@ -1,0 +1,23 @@
+import React from "react";
+import { Alert, Row } from "react-bootstrap";
+
+export default ({ show }) => {
+  if (show) {
+    return (
+      <Row>
+        <Alert bsStyle="danger">
+          There is an issue with your settings configuration. If you are running
+          the front-end code from your local machine, you may need to follow{" "}
+          <a
+            href="https://github.com/aws-samples/amazon-rekognition-engagement-meter/blob/master/CONTRIBUTING.md#working-with-the-web-ui"
+            target="_blank"
+          >
+            this guide
+          </a>
+          .
+        </Alert>
+      </Row>
+    );
+  }
+  return "";
+};

--- a/src/web-ui/src/components/SettingsHelp.js
+++ b/src/web-ui/src/components/SettingsHelp.js
@@ -10,6 +10,7 @@ export default ({ show }) => {
           the front-end code from your local machine, you may need to follow{" "}
           <a
             href="https://github.com/aws-samples/amazon-rekognition-engagement-meter/blob/master/CONTRIBUTING.md#working-with-the-web-ui"
+            rel="noopener noreferrer"
             target="_blank"
           >
             this guide

--- a/src/web-ui/src/utils/request.js
+++ b/src/web-ui/src/utils/request.js
@@ -1,20 +1,12 @@
 import Amplify, { API } from "aws-amplify";
 
-const region = window.rekognitionSettings.region || "eu-west-1";
+const settings = window.rekognitionSettings || {};
+const region = settings.region || "eu-west-1";
 
 Amplify.configure({
-  Auth: {
-    identityPoolId: window.rekognitionSettings.cognitoIdentityPool,
-    region
-  },
+  Auth: { identityPoolId: settings.cognitoIdentityPool, region },
   API: {
-    endpoints: [
-      {
-        name: "apiGateway",
-        endpoint: window.rekognitionSettings.apiGateway,
-        region
-      }
-    ]
+    endpoints: [{ name: "apiGateway", endpoint: settings.apiGateway, region }]
   }
 });
 


### PR DESCRIPTION
Currently, when running the app locally, if the stack hasn't been deployed is hard to guess how to hook the back-end deployed into the cloud to the local front-end.

With this change, in case of a detected missing config, the following alert appears:
![Screenshot 2019-09-23 at 17 08 29](https://user-images.githubusercontent.com/1789893/65442986-20629a80-de25-11e9-853e-751bc87499b6.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
