### PR TITLE
Upgrade deprecated runtime nodejs10.x

### DIFF
--- a/src/cfn/template.yaml
+++ b/src/cfn/template.yaml
@@ -771,7 +771,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       FunctionName: !Sub RekogDemoSetup${CollectionId}
-      Runtime: nodejs10.x
+      Runtime: nodejs14.x
       Handler: index.handler
       CodeUri: ../backend/functions/setup/
       Description: !Sub Custom Lambda resource for the ${CollectionId} Cloudformation Stack


### PR DESCRIPTION
CloudFormation templates in amazon-rekognition-engagement-meter have been found to include a soon to be [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs10.x). The affected templates have been updated to a supported runtime (nodejs14.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.