### PR TITLE
Add consent modal

### DIFF
--- a/src/cfn/template.yaml
+++ b/src/cfn/template.yaml
@@ -12,7 +12,7 @@ Globals:
         CREATE_CLOUDFRONT_DISTRIBUTION: !Ref CreateCloudFrontDistribution
         REGION: !Ref AWS::Region
         TO_BUCKET: !Ref WebUIBucket
-        VERSION: '2.1'
+        VERSION: '2.2'
   Api:
     Cors:
       AllowMethods: "'*'"

--- a/src/web-ui/src/App.js
+++ b/src/web-ui/src/App.js
@@ -9,6 +9,7 @@ import EngagementSummary from "./components/EngagementsSummary";
 import Header from "./components/Header";
 import PolarChart from "./components/PolarChart";
 import SettingsHelp from "./components/SettingsHelp";
+import ConsentModal from "./components/ConsentModal";
 
 import faceDetailsMapper from "./utils/faceDetailsMapper";
 import getChartData from "./utils/getChartData";
@@ -114,6 +115,7 @@ const App = () => {
         addUser={addUser}
         readyToStream={readyToStream}
       />
+      <ConsentModal />
       <Grid>
         <SettingsHelp show={!window.rekognitionSettings} />
         <CameraHelp show={!readyToStream} />

--- a/src/web-ui/src/components/ConsentModal.js
+++ b/src/web-ui/src/components/ConsentModal.js
@@ -1,0 +1,42 @@
+import React from "react";
+import { Button, Modal } from "react-bootstrap";
+import useLocalStorage from "../hooks/useLocalStorage";
+
+const ConsentModal = () => {
+  const [hasConsent, setHasConsent] = useLocalStorage(
+    "rekognitionEngagementMeterConsent",
+    false
+  );
+
+  const onClick = () => {
+    setHasConsent(true);
+  };
+
+  return (
+    <Modal show={!hasConsent} backdrop="static">
+      <Modal.Header>
+        <Modal.Title>Notice</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <p>
+          This feature uses Amazon Web Services. Biometric identifiers and
+          biometric information (“biometric data”) may be collected, stored, and
+          used by Amazon Web Services for the purpose of comparing the image of
+          an individual with a stored image for analysis, verification, fraud,
+          and security purposes. Biometric information that is generated as part
+          of this process will be retained in line with Amazon Web Services
+          privacy policy. You hereby provide your express, informed, written
+          release and consent for Amazon Web Services to collect, use, and store
+          your biometric data as described herein.
+        </p>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="primary" onClick={onClick}>
+          Accept
+        </Button>
+      </Modal.Footer>
+    </Modal>
+  );
+};
+
+export default ConsentModal;

--- a/src/web-ui/src/hooks/useLocalStorage.js
+++ b/src/web-ui/src/hooks/useLocalStorage.js
@@ -1,0 +1,14 @@
+import { useEffect, useState } from "react";
+
+const useLocalStorage = (key, fallback) => {
+  const [value, setValue] = useState(
+    JSON.parse(window.localStorage.getItem(key)) ?? fallback
+  );
+
+  useEffect(() => {
+    window.localStorage.setItem(key, value);
+  }, [key, value]);
+
+  return [value, setValue];
+};
+export default useLocalStorage;

--- a/src/web-ui/src/index.css
+++ b/src/web-ui/src/index.css
@@ -11,3 +11,7 @@ body {
   font-size: 11px;
   text-align: center;
 }
+
+.modal-content {
+  color: #202020;
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds a modal to the app.
The modal provides a notice about the usage of biometric data when using the sample.

The modal is shown the first time the user opens the app. Once a user has acknowledged the notice, the user is not shown the notice again.

I decided to keep all of the state self contained rather than keeping in the `App.js` component.
The `useLocalStorage` hook isn't comprehensive. It seemed overkill to add a new dependency for a fully fleshed out hook, so this is a basic version.

This repo is using an older version of bootstrap. There isn't a tidy way of changing the modal to dark mode to match the rest of the repo short of recreating a lot of the modal CSS. I _think_ it's acceptable

Here's what it looks like
<img width="1011" alt="image" src="https://user-images.githubusercontent.com/17845406/222464154-cc84c2b2-c509-4205-a329-b65d28c1dcda.png">


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
